### PR TITLE
Fix duplicated step definitions

### DIFF
--- a/features/Initial_file_validation.feature
+++ b/features/Initial_file_validation.feature
@@ -6,7 +6,7 @@ Feature: Submit files for initial checking
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   @watch

--- a/features/boolean_value_fields.feature
+++ b/features/boolean_value_fields.feature
@@ -4,7 +4,7 @@ Feature: Submit files where data comprises of Boolean values
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   @watch

--- a/features/check_start_page_links.feature
+++ b/features/check_start_page_links.feature
@@ -5,7 +5,7 @@ Feature: Check help links on the Start page
   @watch
   Scenario: Check the Start page links
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     And I see "landfill emissions" link 1
     Then I click on link one "landfill emissions"
     Then I return to Data Returns

--- a/features/controlled_lists.feature
+++ b/features/controlled_lists.feature
@@ -4,7 +4,7 @@ Feature: Submit files which contain all Controlled list values
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   @watch

--- a/features/date_time_formats_correct.feature
+++ b/features/date_time_formats_correct.feature
@@ -4,7 +4,7 @@ Feature: Check that Dates and/or Dates and Times in UK and ISO formats are accep
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Date and/or Date and Time format - Correct --------------------------

--- a/features/date_time_formats_incorrect.feature
+++ b/features/date_time_formats_incorrect.feature
@@ -5,7 +5,7 @@ Feature: Check that Dates and/or Dates and Times NOT in UK and ISO formats are r
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Date and/or Time format Incorrect --------------------------

--- a/features/error_messages_DR_reference.feature
+++ b/features/error_messages_DR_reference.feature
@@ -4,7 +4,7 @@ Feature: Check that the correct error message is displayed
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Check error DR error message displayed --------------------

--- a/features/header_row_accepted_format.feature
+++ b/features/header_row_accepted_format.feature
@@ -4,7 +4,7 @@ Feature: Check file acceptable header formats
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Valid Header formats --------------------------

--- a/features/header_row_format_invalid.feature
+++ b/features/header_row_format_invalid.feature
@@ -5,7 +5,7 @@ Feature: Check file invalid header formats
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Invalid Header Formats --------------------------

--- a/features/mandatory_incorrect_data.feature
+++ b/features/mandatory_incorrect_data.feature
@@ -4,7 +4,7 @@ Feature: Check file contents for incorrect MANDATORY data
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Mandatory Fields --------------------------

--- a/features/mandatory_missing_and_incorrect_data.feature
+++ b/features/mandatory_missing_and_incorrect_data.feature
@@ -4,7 +4,7 @@ Feature: Check file contents for Missing and incorrect mandatory data
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Mandatory Fields --------------------------

--- a/features/mandatory_missing_data.feature
+++ b/features/mandatory_missing_data.feature
@@ -4,7 +4,7 @@ Feature: Check file contents for missing mandatory data
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Mandatory Fields --------------------------

--- a/features/multiple_files.feature
+++ b/features/multiple_files.feature
@@ -6,19 +6,19 @@ Feature: Submit multiple files
   @watch
   Scenario: Proceed to file selection page
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
     #file 1
     And I choose file "CUKE000_SUCCESS_NO_ERRORS.csv"
     When I click "Check for errors"
     Then I see the page "Confirm your file"
-    And I click the "Confirm and check file" button
+    And I click on the "Confirm and check file" button
     And I input an email address
     Then I click "Send authentication email" button
     Then I am on the "Enter your code" page
     Then I enter the confirmation code
     And I click on the "Continue" button
-    Then I am on "Send your file" page
+    Then I am on the "Send your file" page
     And I select "Accept and send file" button
     Then I am on the last page "File sent"
     Then I click the link "send another data returns file"
@@ -28,8 +28,8 @@ Feature: Submit multiple files
     And I choose multiple file <file>
     When I click "Check for errors"
     Then I see the page "Confirm your file"
-    And I click the "Confirm and check file" button
-    Then I am on "Send your file" page
+    And I click on the "Confirm and check file" button
+    Then I am on the "Send your file" page
     And I select "Accept and send file" button
     Then I am on the last page "File sent"
     Then I click the link "send another data returns file"
@@ -60,7 +60,7 @@ Feature: Submit multiple files
     And I choose file "CUKE000_SUCCESS_NO_ERRORS.csv"
     When I click "Check for errors"
     Then I see the page "Confirm your file"
-    And I click the "Confirm and check file" button
+    And I click on the "Confirm and check file" button
     Then I am on the "Confirm your email address" page
     And I enter an invalid email address
     Then I click "Send email" button
@@ -73,6 +73,6 @@ Feature: Submit multiple files
     Then I am on the "Enter your code" page
     Then I enter the confirmation code
     And I click on the "Continue" button
-    Then I am on "Send your file" page
+    Then I am on the "Send your file" page
     And I select "Accept and send file" button
     Then I am on the last page "File sent"

--- a/features/optional_content_null_validation.feature
+++ b/features/optional_content_null_validation.feature
@@ -4,7 +4,7 @@ Feature: Check acceptance of files where Optional data fields do not contain dat
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Optional Fields ----------------------------------

--- a/features/optional_content_validation.feature
+++ b/features/optional_content_validation.feature
@@ -4,7 +4,7 @@ Feature: Check file contents for incorrect Optional data
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   #------------------ Optional Fields ----------------------------------

--- a/features/step_definitions/navigation_and input.js
+++ b/features/step_definitions/navigation_and input.js
@@ -6,19 +6,11 @@ module.exports = function() {
 
   //------------- Page check navigation -----------------------
 
-  this.Then(/^I see the "([^"]*)" page$/, function(heading) {
-    expect(browser.getText('h1')).toEqual(heading);
-  });
-
   this.Then(/^I see the page "([^"]*)"$/, function(heading) {
     return expect(browser.getText('#T-/file/confirm-47')).toEqual(heading);
   });
 
   this.Then(/^I am on the "([^"]*)" page$/, function(heading) {
-    expect(browser.getText('h1')).toEqual(heading);
-  });
-
-  this.Then(/^I am on "([^"]*)" page$/, function(heading) {
     expect(browser.getText('h1')).toEqual(heading);
   });
 
@@ -31,15 +23,6 @@ module.exports = function() {
     return expect(browser.getText('.heading-xlarge')).toEqual(heading);
   });
 
-  //----- Multiple file submission --------------
-  this.Then(/^I am on the "([^"]*)" page$/, function(emailheading) {
-    expect(browser.getText('h1')).toEqual(emailheading);
-  });
-
-  this.Then(/^I am on the "([^"]*)" page$/, function(emailheading) {
-    expect(browser.getText('h1')).toEqual(emailheading);
-  });
-
   //----------------------Button press -------------
 
   this.Then(/^I select "([^"]*)" button$/, function(button) {
@@ -48,10 +31,6 @@ module.exports = function() {
 
   this.Then(/^I click "([^"]*)"$/, function(heading) {
     return browser.click('#check-for-errors-btn');
-  });
-
-  this.Then(/^I click the "([^"]*)" button$/, function() {
-    return browser.click('.button');
   });
 
   this.Then(/^I click "([^"]*)" button$/, function(button) {

--- a/features/step_definitions/select_file_for_upload.js
+++ b/features/step_definitions/select_file_for_upload.js
@@ -12,10 +12,6 @@ module.exports = function() {
     browser.chooseFile("#file-select-button", `features/support/files/Initial_Validation/${filename}`);
   });
 
-  this.Given(/^I choose file (.*)$/, function(filename) {
-    browser.chooseFile("#file-select-button", `features/support/files/File_Validation/${filename}`);
-  });
-
   this.Then(/^I choose file "([^"]*)"$/, function(filename) {
     browser.chooseFile("#file-select-button", `features/support/files/Initial_Validation/${filename}`);
   });

--- a/features/succesfull_submissions.feature
+++ b/features/succesfull_submissions.feature
@@ -4,7 +4,7 @@ Feature: Submit files where all data passes validation
 
   Background:
     Given I am on the Data Returns page
-    And I see the "Send landfill data returns" page
+    And I am on the "Send landfill data returns" page
     Then I select "Start now" button
 
   @watch
@@ -12,13 +12,13 @@ Feature: Submit files where all data passes validation
     And I choose successfull file <Filename> to upload
     When I click "Check for errors"
     Then I see the page "Confirm your file"
-    And I click the "Confirm and check file" button
+    And I click on the "Confirm and check file" button
     And I input an email address
     Then I click "Send authentication email" button
     Then I am on the "Enter your code" page
     Then I enter the confirmation code
     And I click on the "Continue" button
-    Then I am on "Send your file" page
+    Then I am on the "Send your file" page
     And I select "Accept and send file" button
     Then I am on the last page "File sent"
 


### PR DESCRIPTION
Some scenarios are failing because a step is being called that matches to multiple step methods due to how they've been defined.

This change fixes those duplications. They were
- _I choose file "CUKE000_SUCCESS_NO_ERRORS.csv"_
- _I am on the "Enter your code" page_
- _I am on the "Confirm your email address" page_
