### PR TITLE
Fix failing select button step

### DIFF
--- a/features/Initial_file_validation.feature
+++ b/features/Initial_file_validation.feature
@@ -7,33 +7,33 @@ Feature: Submit files for initial checking
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
-  @watch
+  
   Scenario: Submit a Non-CSV file - valid error message is displayed
     And I choose initial file "CUKE001.png" to upload
     When I click "Check for errors"
     And the text "Your file isn’t saved as CSV" is displayed
 
-  @watch
+  
   Scenario: Submit an Empty file - valid error message is displayed
     And I choose initial file "CUKE002_Empty.csv" to upload
     When I click "Check for errors"
     Then an empty file error message is generated
 
-  @watch
+  
   Scenario: Submit a Security Failure file - valid error message is displayed
     And I choose initial file "CUKE004_VIRUS.csv" to upload
     When I click "Check for errors"
     Then a security fail error message is generated
 
-  @watch
+  
   Scenario: Submit a file exceeding maximum acceptable size - valid error message is displayed
     And I choose initial file "CUKE005_LARGE_FILE_21M_16908_records_FAIL.csv" to upload
     When I click "Check for errors"
     Then a file is too large message is generated
 
-  @watch
+  
   Scenario: Submit a file with incorrect structure - valid error message is displayed
     And I choose initial file "CUKE008_File_structure_data_misalignment_FAIL.csv" to upload
     When I click "Check for errors"

--- a/features/boolean_value_fields.feature
+++ b/features/boolean_value_fields.feature
@@ -5,9 +5,9 @@ Feature: Submit files where data comprises of Boolean values
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
-  @watch
+  
   Scenario Outline: Submit a valid file where the Text Value field holds a Boolean value
     And I choose boolean file <Filename> to upload
     When I click "Check for errors"
@@ -30,7 +30,7 @@ Feature: Submit files where data comprises of Boolean values
       | CUKE7013_OPT_Text_Value_Boolean_1_PASS.csv |
       | CUKE7014_OPT_Text_Value_Boolean_0_PASS.csv |
 
-  @watch
+  
   Scenario Outline: Check that the correct error message is displayed for non Boolean data
     And I choose boolean file <Filename> to upload
     When I click "Check for errors"

--- a/features/check_start_page_links.feature
+++ b/features/check_start_page_links.feature
@@ -2,7 +2,7 @@ Feature: Check help links on the Start page
   Information about the service is provided through links
   on the Start page
 
-  @watch
+  
   Scenario: Check the Start page links
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page

--- a/features/controlled_lists.feature
+++ b/features/controlled_lists.feature
@@ -5,9 +5,9 @@ Feature: Submit files which contain all Controlled list values
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
-  @watch
+  
   Scenario Outline: Submit file comprising all Controlled Lists values
     And I choose Controlled List file <Filename> to upload
     When I click "Check for errors"
@@ -25,7 +25,7 @@ Feature: Submit files which contain all Controlled list values
 
   #|CAS.csv|
   #|RD Code.csv|
-  @watch
+  
   Scenario Outline: Submit file comprising invalid Controlled List value
     And I choose Controlled List file <Filename> to upload
     When I click "Check for errors"

--- a/features/date_time_formats_correct.feature
+++ b/features/date_time_formats_correct.feature
@@ -5,10 +5,10 @@ Feature: Check that Dates and/or Dates and Times in UK and ISO formats are accep
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Date and/or Date and Time format - Correct --------------------------
-  @watch
+  
   Scenario Outline: Valid Date and/or Date and Time formats are accepted
     As a user I want to submit files with data containing
     dates in either UK or ISO format, and where exists containing a time

--- a/features/date_time_formats_incorrect.feature
+++ b/features/date_time_formats_incorrect.feature
@@ -6,10 +6,10 @@ Feature: Check that Dates and/or Dates and Times NOT in UK and ISO formats are r
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Date and/or Time format Incorrect --------------------------
-  @watch
+  
   Scenario Outline: Date/Time - Correct error message displayed where format is incorrect
     Given I choose date file <Filename>
     And I click "Check for errors"

--- a/features/error_messages_DR_reference.feature
+++ b/features/error_messages_DR_reference.feature
@@ -5,10 +5,10 @@ Feature: Check that the correct error message is displayed
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Check error DR error message displayed --------------------
-  @watch
+  
   Scenario: Check that the correct Permit number error message is displayed
     Given I choose failed file "CUKE1001_EA_ID_Incorrect_error.csv" to upload
     When I click "Check for errors"
@@ -16,7 +16,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then Permit number additional details message "DR9000" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Return Type error message is displayed
     Given I choose failed file "CUKE1002_Return_Type_Incorrect_Error.csv" to upload
     When I click "Check for errors"
@@ -24,7 +24,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9010" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Monitoring Date error message is displayed
     Given I choose failed file "CUKE1004_Monitoring_Date_Incorrect_Error.csv" to upload
     When I click "Check for errors"
@@ -32,7 +32,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then Monitoring Date additional details message "DR9020" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Parameter error message is displayed
     Given I choose failed file "CUKE1005_Parameter_Incorrect_Error.csv" to upload
     When I click "Check for errors"
@@ -40,7 +40,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9030" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Value error message is displayed
     Given I choose failed file "CUKE1006_Value_Incorrect_Error.csv" to upload
     When I click "Check for errors"
@@ -48,7 +48,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9040" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Units error message is displayed
     Given I choose failed file "CUKE1007_Unit_Incorrect_Error.csv" to upload
     When I click "Check for errors"
@@ -56,7 +56,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9050" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Monitoring Point error message is displayed
     Given I choose failed file "CUKE1003_Monitoring_Point_Incorrect_Error.csv" to upload
     When I click "Check for errors"
@@ -64,7 +64,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9060" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Monitoring Period error message is displayed
     Given I choose failed file "CUKE4004_OPT_Mon_Period_Non_Controlled_List_FAIL.csv" to upload
     When I click "Check for errors"
@@ -72,7 +72,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9070" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Text Value error message is displayed
     Given I choose failed file "CUKE4013_OPT_Text_Value_Non_Controlled_List_FAIL.csv" to upload
     When I click "Check for errors"
@@ -80,7 +80,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9080" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Reference Period error message is displayed
     Given I choose failed file "CUKE4002_OPT_Ref_Period_Non_Controlled_List_FAIL.csv" to upload
     When I click "Check for errors"
@@ -88,7 +88,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9090" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Method Standard error message is displayed
     Given I choose failed file "CUKE4029_OPT_Meth_Stand_Non_Controlled_List_FAIL.csv" to upload
     When I click "Check for errors"
@@ -96,7 +96,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9100" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Site Name error message is displayed
     Given I choose failed file "CUKE4024_OPT_Site_Name_Special_Characters_FAIL.csv" to upload
     When I click "Check for errors"
@@ -104,7 +104,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9110" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Sample Reference error message is displayed
     Given I choose failed file "CUKE4008_OPT__Smpl_Ref_256_Characters_FAIL.csv" to upload
     When I click "Check for errors"
@@ -112,7 +112,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9120" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Sampled By error message is displayed
     Given I choose failed file "CUKE4011_OPT_Smpl_By_256_Characters_FAIL.csv" to upload
     When I click "Check for errors"
@@ -120,7 +120,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9130" is displayed
 
-  @watch
+  
   Scenario: Check that the correct Comments error message is displayed
     Given I choose failed file "CUKE4027_OPT_Comments_256_Characters_FAIL.csv" to upload
     When I click "Check for errors"
@@ -128,7 +128,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9140" is displayed
 
-  @watch
+  
   Scenario: Check that the correct CiC error message is displayed
     Given I choose failed file "CUKE4034_OPT_CiC_256_Characters_FAIL.csv" to upload
     When I click "Check for errors"
@@ -136,7 +136,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9150" is displayed
 
-  @watch
+  
   Scenario: Check that the correct CAS error message is displayed
     Given I choose failed file "CUKE4038_OPT_CAS_256_Characters_FAIL.csv" to upload
     When I click "Check for errors"
@@ -144,7 +144,7 @@ Feature: Check that the correct error message is displayed
     Then I click "See details of which rows to correct" link
     Then additional details correction message "DR9160" is displayed
 
-  @watch
+  
   Scenario: Check that the correct RD Code error message is displayed
     Given I choose failed file "CUKE4041_OPT_RD_Code_256_Characters_FAIL.csv" to upload
     When I click "Check for errors"

--- a/features/header_row_accepted_format.feature
+++ b/features/header_row_accepted_format.feature
@@ -5,10 +5,10 @@ Feature: Check file acceptable header formats
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Valid Header formats --------------------------
-  @watch
+  
   Scenario Outline: Submit files with accepted header structures
     And I choose header file <Filename> to upload
     When I click "Check for errors"

--- a/features/header_row_format_invalid.feature
+++ b/features/header_row_format_invalid.feature
@@ -6,10 +6,10 @@ Feature: Check file invalid header formats
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Invalid Header Formats --------------------------
-  @watch
+  
   Scenario Outline: Check for missing header name only
     And I choose header file <Filename> to upload
     When I click "Check for errors"
@@ -26,7 +26,7 @@ Feature: Check file invalid header formats
       | CUKE5014_Missing_Value_Header.csv |
       | CUKE5016_Missing_Unit_Header.csv |
 
-  @watch
+  
   Scenario Outline: Check for missing header name and associated comma
     And I choose header file <Filename> to upload
     When I click "Check for errors"
@@ -42,7 +42,7 @@ Feature: Check file invalid header formats
       | CUKE5015_Missing_Value_Header_and_comma.csv |
       | CUKE5017_Missing_Unit_Header_and_comma.csv |
 
-  @watch
+  
   Scenario Outline: Check for non-specification header name
     And I choose header file <Filename> to upload
     When I click "Check for errors"

--- a/features/mandatory_incorrect_data.feature
+++ b/features/mandatory_incorrect_data.feature
@@ -5,10 +5,10 @@ Feature: Check file contents for incorrect MANDATORY data
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Mandatory Fields --------------------------
-  @watch
+  
   Scenario Outline: For MANDATORY fields check that the correct error message is displayed
     for records where data is Incorrect
     Given I choose file <Filename>

--- a/features/mandatory_missing_and_incorrect_data.feature
+++ b/features/mandatory_missing_and_incorrect_data.feature
@@ -5,10 +5,10 @@ Feature: Check file contents for Missing and incorrect mandatory data
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Mandatory Fields --------------------------
-  @watch
+  
   Scenario Outline: For MANDATORY fields check that the correct error message is displayed
     for records where data is Missing and incorrect
     Given I choose file <Filename>

--- a/features/mandatory_missing_data.feature
+++ b/features/mandatory_missing_data.feature
@@ -5,10 +5,10 @@ Feature: Check file contents for missing mandatory data
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Mandatory Fields --------------------------
-  @watch
+  
   Scenario Outline: For MANDATORY fields check that the correct error message is displayed
     for records where data is Missing
     Given I choose file <Filename>

--- a/features/multiple_files.feature
+++ b/features/multiple_files.feature
@@ -3,11 +3,11 @@ Feature: Submit multiple files
   file (Max 10) without having to obtain further
   authorisation codes
 
-  @watch
+  
   Scenario: Proceed to file selection page
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
     #file 1
     And I choose file "CUKE000_SUCCESS_NO_ERRORS.csv"
     When I click "Check for errors"
@@ -23,7 +23,7 @@ Feature: Submit multiple files
     Then I am on the last page "File sent"
     Then I click the link "send another data returns file"
 
-  @watch
+  
   Scenario Outline: Submit a valid file
     And I choose multiple file <file>
     When I click "Check for errors"
@@ -55,7 +55,7 @@ Feature: Submit multiple files
       #file 10
       | CUKE006_LARGE_FILE_MAX_21M_16907_records_PASS.csv |
 
-  @watch
+  
   Scenario: Enter an invalid format email address
     And I choose file "CUKE000_SUCCESS_NO_ERRORS.csv"
     When I click "Check for errors"
@@ -66,7 +66,7 @@ Feature: Submit multiple files
     Then I click "Send email" button
     And an invalid email error message is shown
 
-  @watch
+  
   Scenario: Re-enter the correct email address used previously
     And I input an email address
     Then I click "Send authentication email" button

--- a/features/optional_content_null_validation.feature
+++ b/features/optional_content_null_validation.feature
@@ -5,10 +5,10 @@ Feature: Check acceptance of files where Optional data fields do not contain dat
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Optional Fields ----------------------------------
-  @watch
+  
   Scenario Outline: For OPTIONAL fields check that the correct error message is displayed
     where data for submitted records is Incorrect
     Given I choose file <Filename>

--- a/features/optional_content_validation.feature
+++ b/features/optional_content_validation.feature
@@ -5,10 +5,10 @@ Feature: Check file contents for incorrect Optional data
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
   #------------------ Optional Fields ----------------------------------
-  @watch
+  
   Scenario Outline: For OPTIONAL fields check that the correct error message is displayed
     where data for submitted records is Incorrect
     Given I choose file <Filename>

--- a/features/step_definitions/navigation_and input.js
+++ b/features/step_definitions/navigation_and input.js
@@ -25,8 +25,12 @@ module.exports = function() {
 
   //----------------------Button press -------------
 
-  this.Then(/^I select "([^"]*)" button$/, function(button) {
+  this.Then(/^I start my submission$/, function() {
     return browser.click('.button-get-started');
+  });
+
+  this.Then(/^I select "([^"]*)" button$/, function(button) {
+    return browser.click('.button');
   });
 
   this.Then(/^I click "([^"]*)"$/, function(heading) {

--- a/features/successful_submissions.feature
+++ b/features/successful_submissions.feature
@@ -5,9 +5,9 @@ Feature: Submit files where all data passes validation
   Background:
     Given I am on the Data Returns page
     And I am on the "Send landfill data returns" page
-    Then I select "Start now" button
+    Then I start my submission
 
-  @watch
+  @focus
   Scenario Outline: Submit a valid file
     And I choose successfull file <Filename> to upload
     When I click "Check for errors"


### PR DESCRIPTION
A number of scenarios rely on a step that selects an element with the class `.button`. However they are failing because the underlying web driver cannot find it.

This change fixes those steps that are failing due to the step being unable to find the right button to select.
