### PR TITLE
Fix invalid data tables in 2 feature files

### DIFF
--- a/features/mandatory_missing_data.feature
+++ b/features/mandatory_missing_data.feature
@@ -8,7 +8,7 @@ Feature: Check file contents for missing mandatory data
     Then I start my submission
 
   #------------------ Mandatory Fields --------------------------
-  
+
   Scenario Outline: For MANDATORY fields check that the correct error message is displayed
     for records where data is Missing
     Given I choose file <Filename>
@@ -18,7 +18,7 @@ Feature: Check file contents for missing mandatory data
     Then I click "See details of which rows to correct" link
 
     Examples:
-      | Filename | DRref | Header | Error | DRef | DetError |
+      | Filename | DRref | Header | Error | DRef |
       | CUKE2001_EA_ID_Missing_Error.csv | DR9000 | EA_ID | Missing | Missing |
       | CUKE2002_Return_Type_Missing_Error.csv | DR9010 | Rtn_Type | Missing | Missing |
       | CUKE2003_Monitoring_Point_Missing_Error.csv | DR9060 | Mon_Point | Missing | Missing |

--- a/features/optional_content_null_validation.feature
+++ b/features/optional_content_null_validation.feature
@@ -8,7 +8,7 @@ Feature: Check acceptance of files where Optional data fields do not contain dat
     Then I start my submission
 
   #------------------ Optional Fields ----------------------------------
-  
+
   Scenario Outline: For OPTIONAL fields check that the correct error message is displayed
     where data for submitted records is Incorrect
     Given I choose file <Filename>
@@ -16,7 +16,7 @@ Feature: Check acceptance of files where Optional data fields do not contain dat
     Then I see the page "Confirm your file"
 
     Examples:
-      | Filename | DRef |
+      | Filename | 
       | CUKE4001_OPT_Ref_Period_Null_PASS.csv |
       | CUKE4006_OPT_Mon_Period_NULL_PASS.csv |
       | CUKE4009_OPT__Smpl_Ref_NULL_PASS.csv |


### PR DESCRIPTION
The tests are currently not running due to a Gherkin parser error. Upon investigation the cause was found to be data tables that featured header columns that didn't exist in the detail.

This change removes the problem headers and the tests now run again.
