### PR TITLE
Add test for replacement character substitution

### DIFF
--- a/features/substitution.feature
+++ b/features/substitution.feature
@@ -47,3 +47,11 @@ Feature: Submit files with alias alternative values
     Examples:
       | Filename                   |
       | CHARACTER_SUBSTITUTION.csv |
+
+  Scenario Outline: Non printing unicode characters are converted to whitespace
+    Given I choose file <Filename> to upload
+    Then I expect the file status for <Filename> to be "READY TO SEND"
+
+    Examples:
+      | Filename                    |
+      | NON_PRINTING_CHARACTERS.csv |

--- a/features/support/files/NON_PRINTING_CHARACTERS.csv
+++ b/features/support/files/NON_PRINTING_CHARACTERS.csv
@@ -1,0 +1,3 @@
+EA_ID,Site_Name,Rtn_Type,Mon_Date,Rtn_Period,Mon_Point,Parameter,Value,Unit,Ref_Period
+47017,Silvertrees Landfill,Landfill gas borehole,05/08/2015,Qtr 2 2016,Monitor point 1,"16-(Thienylmethylene)Androstane-3,17-Diol SVOCS",123,ÂºC,Instantaneous
+TP3433GQ,Kibblesworth LTP EPR/TP3433GQ,Landfill gas borehole,06/08/2015,Qtr 2 2017,Monitor point 2,"2,2',3,3',4,4',5.6'-Octachlorobiphenyl",123,ÂºC,Instantaneous


### PR DESCRIPTION
When the data is copied from the look-up or controlled list search results
pages in the browser the search marker causes the copy mechanism in windows and MAC
to insert a non-breaking space character 0A into the copy buffer.

When the data is transmitted in the multi-part form the 0A character is converted into
utf-8 encoded unicode and the bytes C2 OA (49,824) are transmitted.

The C2 0A is converted when it is stored as a Java utf-8 string as FF FD - the replacement character
- it is used to replace any incoming character whose value is unknown or unrepresentable
in unicode.

So to get around this the system will replace the REPLACEMENT_CHARACTER as a single space
which will have the perhaps undesirable side-effect of rendering any non-printing unicode character
as a space. It is preferable however to the effects given by cut-and-paste operations in the browser.
