### PR TITLE
Fixed formatting of header in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Open a terminal and ensure you are at the root of the project. Then simply run
 chimp
 ```
 
-####Browserstack
+#### Browserstack
 To run on browserstack additional configuration files are required:
 
 **/browserstacklocal.json**


### PR DESCRIPTION
Github flavoured markdown requires an explicit whitespace after a  heading `#`